### PR TITLE
Add Vector2Provider, related classes and DummyPlayerMove

### DIFF
--- a/1_MonoFSM_Core/Runtime/0_Pattern/DataProvider/IVector2Provider.cs
+++ b/1_MonoFSM_Core/Runtime/0_Pattern/DataProvider/IVector2Provider.cs
@@ -1,0 +1,39 @@
+using System;
+using MonoFSM.Core.Attributes;
+using MonoFSM.Variable;
+using Sirenix.OdinInspector;
+using UnityEngine.Scripting.APIUpdating;
+using UnityEngine.Serialization;
+using UnityEngine;
+
+namespace MonoFSM.Core.DataProvider
+{
+    public interface IVector2Provider : IValueProvider<Vector2> { }
+
+    [InlineProperty]
+    [Serializable]
+    public class VarVector2DropDownRef : IVector2Provider //FIXME: 改名成 DropdownVarVector2?
+    {
+        [HideLabel]
+        [DropDownRef]
+        public VarVector2 _monoVar;
+
+        public Vector2 Value => _monoVar?.FinalValue ?? Vector2.zero;
+
+        public string Description => _monoVar?._varTag?.name;
+
+        public T GetValue<T>()
+        {
+            if (typeof(T) == typeof(Vector2)) return (T)(object)_monoVar?.FinalValue;
+
+            throw new InvalidCastException($"Cannot cast {typeof(float)} to {typeof(T)}");
+        }
+
+        public Type ValueType => typeof(Vector2);
+
+        public string GetDescription()
+        {
+            return _monoVar?.FinalValue.ToString();
+        }
+    }
+}

--- a/1_MonoFSM_Core/Runtime/0_Pattern/DataProvider/IVector2Provider.cs.meta
+++ b/1_MonoFSM_Core/Runtime/0_Pattern/DataProvider/IVector2Provider.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 767bc18e822af8449ae8913b17f6d1eb

--- a/1_MonoFSM_Core/Runtime/2_Variable/FlagField.cs
+++ b/1_MonoFSM_Core/Runtime/2_Variable/FlagField.cs
@@ -55,6 +55,20 @@ public class FlagFieldFloat : FlagField<float>
 
 
 [Serializable]
+public class FlagFieldVector2 : FlagField<Vector2>
+{
+    public static bool operator ==(FlagFieldVector2 j, Vector2 k) 
+        => j.CurrentValue == k;
+
+    public static bool operator !=(FlagFieldVector2 j, Vector2 k) 
+        => j.CurrentValue != k;
+
+    protected override bool IsCurrentValueEquals(Vector2 value) 
+        => _currentValue == value;
+}
+
+
+[Serializable]
 public class ValueChangedListener<T>
 {
     public void Clear()

--- a/1_MonoFSM_Core/Runtime/2_Variable/VarVector2.cs
+++ b/1_MonoFSM_Core/Runtime/2_Variable/VarVector2.cs
@@ -1,0 +1,16 @@
+using RCGExtension;
+using UnityEngine;
+using MonoFSM.Core.Attributes;
+using MonoFSM.Variable.FieldReference;
+
+namespace MonoFSM.Variable
+{
+    public class VarVector2 :
+    GenericMonoVariable<GameDataVector2, FlagFieldVector2, Vector2>,
+        IHierarchyValueInfo
+    {
+        public string ValueInfo => CurrentValue.ToString();
+        public bool IsDrawingValueInfo => true;
+        public override bool IsValueExist => CurrentValue != Vector2.zero;
+    }
+}

--- a/1_MonoFSM_Core/Runtime/2_Variable/VarVector2.cs.meta
+++ b/1_MonoFSM_Core/Runtime/2_Variable/VarVector2.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b00e7494a4321b24fb83ef478173579d

--- a/1_MonoFSM_Core/Runtime/3_FlagData/GameDataVector2.cs
+++ b/1_MonoFSM_Core/Runtime/3_FlagData/GameDataVector2.cs
@@ -1,0 +1,16 @@
+using System;
+using Sirenix.OdinInspector;
+using UnityEngine;
+
+[CreateAssetMenu(fileName = "NewVector2Flag", menuName = "GameFlag/Vector2", order = 1)]
+public class GameDataVector2 : AbstractScriptableData<FlagFieldVector2, Vector2>
+{
+    public override Vector2 CurrentValue
+    {
+        get => base.CurrentValue;
+        set
+        {
+            base.CurrentValue = value;
+        }
+    }
+}

--- a/1_MonoFSM_Core/Runtime/3_FlagData/GameDataVector2.cs.meta
+++ b/1_MonoFSM_Core/Runtime/3_FlagData/GameDataVector2.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0fb912ed270652c47adaf13527ee4cbf

--- a/MonoFSM_Physics/Runtime/Interact/Player2DAxisActionReader.cs
+++ b/MonoFSM_Physics/Runtime/Interact/Player2DAxisActionReader.cs
@@ -1,0 +1,32 @@
+using MonoFSM.Core.Attributes;
+using MonoFSM.Core.Runtime.Action;
+using MonoFSM.Variable;
+using UnityEngine;
+using UnityEngine.InputSystem;
+using UnityEngine.Serialization;
+
+namespace MonoFSM_Physics.Runtime
+{
+    public class Player2DAxisActionReader : AbstractStateAction
+    {
+        [DropDownRef]
+        [SerializeField] VarVector2 _axisValueProvider;
+
+        [FormerlySerializedAs("ActionRef")] public InputActionReference _actionRef;
+
+        [PreviewInInspector][AutoParent] private PlayerInput playerInput;
+
+        private InputAction action =>
+            playerInput != null && _actionRef != null ? playerInput.actions[_actionRef.action.name] : null;
+
+        [PreviewInInspector]
+        public Vector2 axisValue =>
+            action?.ReadValue<Vector2>() ?? Vector2.zero;
+
+        protected override void OnActionExecuteImplement()
+        {
+            if (action == null) return;
+            _axisValueProvider.SetValue(axisValue, this);
+        }
+    }
+}

--- a/MonoFSM_Physics/Runtime/Interact/Player2DAxisActionReader.cs.meta
+++ b/MonoFSM_Physics/Runtime/Interact/Player2DAxisActionReader.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 54951aee48297194289746832b96a3ae

--- a/MonoFSM_Physics/Runtime/PhysicsAction/DummyPlayerMove.cs
+++ b/MonoFSM_Physics/Runtime/PhysicsAction/DummyPlayerMove.cs
@@ -1,0 +1,26 @@
+using MonoFSM.Core;
+using MonoFSM.Core.Runtime.Action;
+using MonoFSM.Variable;
+using MonoFSM.Variable.Attributes;
+using Sirenix.OdinInspector;
+using UnityEngine;
+using MonoFSM.Core.Attributes;
+
+namespace MonoFSM_Physics.Runtime.PhysicsAction
+{
+    public class DummyPlayerMove : AbstractStateAction
+    {
+        [Required] [CompRef] [AutoChildren] private ICompProvider<Rigidbody> _rigidbodyProvider;
+        [Required] [CompRef] [AutoChildren] VarVector2 _axisValueProvider;
+        [ShowInDebugMode] Vector2? targetDirection => _axisValueProvider?.CurrentValue;
+        [SerializeField] float speed = 5f;
+
+        protected override void OnActionExecuteImplement()
+        {
+            var rb = _rigidbodyProvider.Get();
+            rb.isKinematic = true;
+            var targetPosition = rb.transform.position + (Vector3)targetDirection * speed * Time.deltaTime;
+            rb.MovePosition(targetPosition);
+        }
+    }
+}

--- a/MonoFSM_Physics/Runtime/PhysicsAction/DummyPlayerMove.cs.meta
+++ b/MonoFSM_Physics/Runtime/PhysicsAction/DummyPlayerMove.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a1e2975dc537ad64091e8fa7c89a2640


### PR DESCRIPTION
`DummyPlayerMove` moves the dummy player based on its `VarVector2` value,
which can be updated by `Player2DAxisActionReader`.

I've tried to implement it by `Vector2?`, but encountered the following error:
```cs
The type 'UnityEngine.Vector2?' cannot be used as type parameter 'TType' in the generic type or method 'GenericMonoVariable<TScriptableData, TField, TType>'. The nullable type 'UnityEngine.Vector2?' does not satisfy the constraint of 'System.IEquatable<UnityEngine.Vector2?>'. Nullable types can not satisfy any interface constraints.
```

So currently I use Vector2 to implement it, and checking for value existence like this:
```cs
IsValueExist => CurrentValue != Vector2.zero
```